### PR TITLE
Modernize ember-oil-pastels install for Node 20 and restore hi-* palette

### DIFF
--- a/app/styles/jamie-colors.scss
+++ b/app/styles/jamie-colors.scss
@@ -53,4 +53,13 @@ $oil-pastels: (
   'dark-carmine':       #772d24,
   'dark-green':         #2b463e,
   'black':              #343435,
+
+  'hi-yellow':          #fcf939,
+  'hi-green':           #a3fe72,
+  'hi-blue':            #5dd2fd,
+  'hi-pink':            #fe3d89,
+  'hi-orange':          #ff733d,
+  'hi-red':             #fc383c,
+  'hi-violet':          #fe6cce,
+  'hi-cyan':            #00ffe1,
 );

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
-/* jshint node: true */
 'use strict';
 
 module.exports = {
-  name: 'ember-jamie-pastels'
+  name: require('./package').name
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "ember-oil-pastels",
+  "version": "0.0.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ember-oil-pastels",
+      "version": "0.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,50 +2,21 @@
   "name": "ember-oil-pastels",
   "version": "0.0.2",
   "description": "Jamie's oil pastels in SCSS as an Ember addon",
-  "directories": {
-    "doc": "doc",
-    "test": "tests"
-  },
-  "scripts": {
-    "build": "ember build",
-    "start": "ember server",
-    "test": "ember try:testall"
-  },
-  "repository": "",
-  "engines": {
-    "node": ">= 0.10.0"
-  },
-  "author": "@openhouse",
-  "license": "MIT",
-  "devDependencies": {
-    "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "0.7.1",
-    "ember-cli": "2.5.1",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^1.4.0",
-    "ember-cli-release": "0.2.8",
-    "ember-cli-sass": "5.3.1",
-    "ember-cli-sri": "^2.1.0",
-    "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.5.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
-    "ember-resolver": "^2.0.3",
-    "ember-try": "^0.2.2",
-    "loader.js": "^4.0.1"
-  },
   "keywords": [
     "ember-addon"
   ],
-  "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+  "repository": "",
+  "license": "MIT",
+  "author": "@openhouse",
+  "engines": {
+    "node": ">=18"
   },
+  "files": [
+    "app/",
+    "index.js",
+    "README.md",
+    "LICENSE.md"
+  ],
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }


### PR DESCRIPTION
### Motivation
- Consumers install this addon as a git dependency and npm installs devDependencies during prepare, which pulled in `node-sass` (native build) via old Ember CLI tooling and failed on Node 20+. 
- The addon is effectively a styles-only package, so the simplest fix is to remove install-time native build paths and keep the public SCSS API stable. 
- FairRentNYC depends on `@import "oil-pastels"` and `map-get($oil-pastels, "hi-pink")`-style lookups, so the `hi-*` keys must be present. 
- Also keep addon name and package metadata consistent and align `engines.node` for modern Node usage.

### Description
- Simplified `package.json` to a minimal, buildless styles-only package by removing the Ember CLI-era devDependencies that pulled in `node-sass`. 
- Set `engines.node` to `>=18` and added a `files` whitelist to ensure only required assets (`app/`, `index.js`, `README.md`, `LICENSE.md`) are shipped. 
- Updated `index.js` to derive the addon name from `package.json` via `name: require('./package').name` so package and addon names stay in sync. 
- Restored `hi-*` highlight colors in `app/styles/jamie-colors.scss` so the `$oil-pastels` map contains `hi-yellow`, `hi-green`, `hi-blue`, `hi-pink`, `hi-orange`, `hi-red`, `hi-violet`, and `hi-cyan`, and left `app/styles/oil-pastels.scss` unchanged so `@import "oil-pastels"` still exposes `$oil-pastels`.
- Added a minimal `package-lock.json` representing the dependency-free install graph.

### Testing
- Ran `npm install` in a clean checkout and it completed successfully with no native build steps. (succeeded) 
- Ran `npm ls node-sass` and confirmed the tree is empty / no `node-sass` present. (succeeded) 
- Verified the `hi-*` keys exist via a code search (`rg "hi-(pink|blue|green|yellow|orange|red|violet|cyan)" app/styles/jamie-colors.scss`). (succeeded) 
- Verified `app/styles/oil-pastels.scss` still imports `jamie-colors.scss`, preserving the public SCSS import and `$oil-pastels` contract. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69911f619e408330a26737d803707379)